### PR TITLE
Add shebang to allow running directly with execution bit

### DIFF
--- a/PotionWars.py
+++ b/PotionWars.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 """
 Copyright 2014, 2015 Andrew Russell
 


### PR DESCRIPTION
When you `chmod +x PotionWars.py` in an OS that supports executable bits (OSX and Linux), it interprets your copyright as the shell... Adding this "Shebang" makes it runnable like a native program so you can invoke it like:

    ./PotionWars.py

Rather than:

    python PotionWars.py